### PR TITLE
Fix file creation

### DIFF
--- a/lib/torrent/createfiles.js
+++ b/lib/torrent/createfiles.js
@@ -1,4 +1,3 @@
-
 var File = require('../file')
   , fs = require('fs')
   , path = require('path')
@@ -40,11 +39,11 @@ function nextFile(basePath, files, processedFiles, offset, callback) {
     var file = files.shift()
       , pathArray = file.path.slice(0)
       ;
-    checkPath(basePath, pathArray, function(error) {
+    checkPath(basePath, pathArray, function(error, filePath) {
       if (error) {
         callback(error);
       } else {
-        processedFiles.push(new File(path.join(basePath, pathArray[0]), file.length, 
+        processedFiles.push(new File(path.join(filePath, pathArray[0]), file.length, 
             offset, function(error) {
           if (error) {
             callback(new Error('Error creating file, error = ' + error));
@@ -62,7 +61,7 @@ function nextFile(basePath, files, processedFiles, offset, callback) {
 
 function checkPath(basePath, pathArray, callback) {
   if (pathArray.length === 1) {
-    callback(null);
+    callback(null, basePath);
   } else {
     var currentPath = path.join(basePath, pathArray.shift());
     makeDirectory(currentPath, function(error) {


### PR DESCRIPTION
Ensure checkPath passes the actual file path to its callback, so that files are created in the right directory instead of the torrent basePath.
