### PR TITLE
Basic torrent persistence

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -71,6 +71,33 @@ Client.prototype.removeTorrent = function(torrent) {
   }
 };
 
+Client.prototype.getPersistData = function() {
+  var client = this;
+
+  return Object.keys(client.torrents).reduce(function(data, infoHash) {
+    data[infoHash] = client.torrents[infoHash].getPersistData();
+    return data;
+  }, {});
+};
+
+Client.prototype.restorePersistData = function(data) {
+  var client = this;
+  var torrents = [];
+
+  Object.keys(data).forEach(function(infoHash) {
+    if (client.torrents[infoHash]) {
+      LOGGER.warn('Torrent %s not overwritten while restoring data', infoHash);
+    } else {
+      var torrent = Torrent.fromPersistData(client.id, client.port, client._extensions, data[infoHash]);
+
+      client.torrents[infoHash] = torrent;
+      torrents.push(torrent);
+    }
+  });
+
+  return torrents;
+};
+
 Client.prototype._handleConnection = function(stream) {
   var peer = new Peer(stream),
       client = this;

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -8,10 +8,10 @@ var bencode = require('./util/bencode'),
 
 var LOGGER = require('log4js').getLogger('metadata.js');
 
-function Metadata(infoHash, metadata) {
+function Metadata(infoHash, metadata, persistBitfield) {
   EventEmitter.call(this);
   this.infoHash = infoHash;
-  this.bitfield = null;
+  this.bitfield = persistBitfield ? new Bitfield(persistBitfield.buffer, persistBitfield.length) : null;
   this._encodedMetadata = null;
   this._length = 0;
   this.setMetadata(metadata);
@@ -91,6 +91,22 @@ Metadata.prototype.setPiece = function(index, data) {
   if (this.isComplete()) {
     this.setMetadata(bencode.decode(this._encodedMetadata.toString('binary')));
   }
+};
+
+Metadata.prototype.getPersistData = function() {
+  return {
+    infoHash: this.infoHash,
+    encoded: this._encodedMetadata,
+    bitfield: this.bitfield ? { buffer: this.bitfield.toBuffer(), length: this.bitfield.length } : null
+  };
+};
+
+Metadata.fromPersistData = function(persistData) {
+  return new Metadata(
+    persistData.infoHash,
+    bencode.decode(persistData.toString('binary')),
+    persistData.bitfield
+  );
 };
 
 Metadata.COMPLETE = 'metadata:complete';

--- a/lib/piece.js
+++ b/lib/piece.js
@@ -9,10 +9,15 @@ var File = require('./file');
 
 var LOGGER = require('log4js').getLogger('piece.js');
 
-var Piece = function(index, offset, length, hash, files, callback) {
+var Piece = function(index, offset, length, hash, files, persistBitfield, callback) {
   EventEmitter.call(this);
 
-  this.complete = new BitField(Math.ceil(length / Piece.CHUNK_LENGTH));
+  if (persistBitfield) {
+    this.complete = new BitField(persistBitfield.buffer, persistBitfield.length);
+  } else {
+    this.complete = new BitField(Math.ceil(length / Piece.CHUNK_LENGTH));
+  }
+
   this.files = [];
   this.hash = hash;
   this.index = index;
@@ -40,6 +45,12 @@ var Piece = function(index, offset, length, hash, files, callback) {
     if (valid) {
       setState(self, Piece.COMPLETE);
     } else {
+      if (persistBitfield && self.complete.cardinality === self.complete.length) {
+        LOGGER.debug('Invalid persisted piece, clearing');
+        self.complete = new BitField(self.complete.length);
+        self.requested = new BitField(self.complete.length);
+      }
+
       setState(self, Piece.INCOMPLETE);
     }
     callback();
@@ -175,6 +186,13 @@ function setState(self, state) {
   self.state = state;
   self.emit(state, self);
 }
+
+Piece.prototype.getPersistData = function() {
+  return {
+    buffer: this.complete.toBuffer(),
+    length: this.complete.length
+  };
+};
 
 Piece.CHUNK_LENGTH = 16384;
 

--- a/lib/torrent/createpieces.js
+++ b/lib/torrent/createpieces.js
@@ -2,17 +2,17 @@ var Piece = require('../piece');
 
 var LOGGER = require('log4js').getLogger('createpieces.js');
 
-function createPieces(hashes, files, pieceLength, sizeOfDownload, callback) {
+function createPieces(hashes, files, pieceLength, sizeOfDownload, persistPieces, callback) {
   var pieces = [],
     numberOfPieces = hashes.length / 20,
     currentIndex = 0;
   
   createPiece(pieces, hashes, files, currentIndex, numberOfPieces, pieceLength,
-    sizeOfDownload, callback);
+    sizeOfDownload, persistPieces, callback);
 }
 
 function createPiece(pieces, hashes, files, currentIndex, numberOfPieces, pieceLength, 
-    sizeOfDownload, callback) {
+    sizeOfDownload, persistPieces, callback) {
   if (currentIndex === numberOfPieces) {
     callback(null, pieces);
   } else {
@@ -23,7 +23,7 @@ function createPiece(pieces, hashes, files, currentIndex, numberOfPieces, pieceL
       lengthOfNextPiece = sizeOfDownload % pieceLength;
     }
     var piece = new Piece(currentIndex, currentIndex * pieceLength, lengthOfNextPiece, hash,
-        files, function() {
+        files, persistPieces[currentIndex], function() {
       createPiece(pieces, hashes, files, currentIndex + 1, numberOfPieces, pieceLength, 
         sizeOfDownload, callback);
     });

--- a/lib/torrent/torrent.js
+++ b/lib/torrent/torrent.js
@@ -19,7 +19,7 @@ var BitField = require('../util/bitfield'),
 
 var LOGGER = require('log4js').getLogger('torrent.js');
 
-function Torrent(clientId, clientPort, downloadPath, dataUrl, extensions) {
+function Torrent(clientId, clientPort, downloadPath, dataUrl, extensions, persistData) {
   EventEmitter.call(this);
 
   this.clientId = clientId;
@@ -45,25 +45,39 @@ function Torrent(clientId, clientPort, downloadPath, dataUrl, extensions) {
   this._requestManager = new RequestManager(this);
   this._files = [];
   this._pieces = [];
-  this._downloadPath = downloadPath;
   this._extensions = extensions;
   this._extensionMap = null;
 
   var torrent = this;
+
   // load torrent data
-  TorrentData.load(dataUrl, function(error, metadata, trackers) {
-    if (error) {
-      LOGGER.warn('Error loading torrent data. error = %j', error);
-      torrent._setStatus(Torrent.ERROR, error);
-    } else {
-      LOGGER.debug('Torrent data loaded.');
-      torrent._metadata = metadata;
-      trackers.forEach(function(tracker) {
-        torrent.addTracker(tracker);
-      });
-      torrent._initialise();
-    }
-  });
+  if (persistData) {
+    LOGGER.debug('Loading persisted torrent data');
+    
+    this._downloadPath = persistData.downloadPath;
+    this._metadata = Metadata.fromPersistData(persistData.metadata);
+
+    Tracker.createTrackers(null, persistData.trackers).forEach(function(tracker) {
+      torrent.addTracker(tracker);
+    });
+    torrent._initialise(persistData.bitfield, persistData.pieces);
+  } else {
+    this._downloadPath = downloadPath;
+
+    TorrentData.load(dataUrl, function(error, metadata, trackers) {
+      if (error) {
+        LOGGER.warn('Error loading torrent data. error = %j', error);
+        torrent._setStatus(Torrent.ERROR, error);
+      } else {
+        LOGGER.debug('Torrent data loaded.');
+        torrent._metadata = metadata;
+        trackers.forEach(function(tracker) {
+          torrent.addTracker(tracker);
+        });
+        torrent._initialise();
+      }
+    });
+  }
 }
 util.inherits(Torrent, EventEmitter);
 
@@ -187,7 +201,7 @@ Torrent.prototype.setMetadata = function(metadata) {
   this._initialise();
 };
 
-Torrent.prototype._initialise = function() {
+Torrent.prototype._initialise = function(persistBitfield, persistPieces) {
 
   LOGGER.debug('Initialising torrent.');
   if (this.status === Torrent.READY) {
@@ -229,12 +243,18 @@ Torrent.prototype._initialise = function() {
         torrent.size = _size;
 
         createPieces(torrent._metadata.pieces, _files, torrent._metadata['piece length'],
-            _size, function(error, _pieces) {
+            _size, persistPieces, function(error, _pieces) {
           if (error) {
             torrent._setStatus(Torrent.ERROR, error);
           } else {
             torrent._pieces = _pieces;
-            torrent.bitfield = new BitField(_pieces.length);
+
+            if (persistBitfield) {
+              torrent.bitfield = new BitField(persistBitfield.buffer, persistBitfield.length);
+            } else {
+              torrent.bitfield = new BitField(_pieces.length);
+            }
+
             var completeHandler = torrent._pieceComplete.bind(torrent);
             _pieces.forEach(function(piece) {
               if (piece.isComplete()) {
@@ -280,6 +300,28 @@ Torrent.prototype._setStatus = function(status, data) {
   if (status === Torrent.ERROR) {
     this.stop();
   }
+};
+
+Torrent.prototype.getPersistData = function() {
+  if (!this._metadata || this.trackers.length === 0) {
+    throw new Error('Cannot persist torrent without metadata or trackers');
+  }
+
+  return {
+    downloadPath: this._downloadPath,
+    metadata: this._metadata.getPersistData() : null,
+    trackers: this.trackers.map(function(tracker) {
+      return tracker.getPersistData();
+    },
+    bitfield: this.bitfield ? { buffer: this.bitfield.toBuffer(), length: this.bitfield.length } : null,
+    pieces: this.pieces.map(function(piece) {
+      return piece.getPersistData();
+    })
+  };
+};
+
+Torrent.fromPersistData = function(clientId, clientPort, extensions, data) {
+  return new Torrent(clientId, clientPort, null, null, extensions, data);
 };
 
 Torrent.COMPLETE = 'torrent:complete';

--- a/lib/tracker/tracker.js
+++ b/lib/tracker/tracker.js
@@ -110,6 +110,10 @@ Tracker.prototype._updateInfo = function(data) {
   }
 };
 
+Tracker.prototype.getPersistData = function() {
+  return this.url;
+};
+
 Tracker.createTrackers = function(announce, announceList) {
   var trackers = [];
   if (announceList) {


### PR DESCRIPTION
Here is my take on torrent persistence.

From a user's point of view here's how it is intended to be used:

``` js
var data = client.getPersistData();
// Store data somewhere, stop the client
// (any further progress won't be saved of course)

// ... later retrieve the data, create a new client and restore torrents
var torrents = client.restorePersistData(data);
```

`getPersistData` returns an object holding persistent data (including some Buffers). It includes the following for every torrent:
- download path
- bitfield
- tracker announce urls
- piece bitfields
- metadata (infoHash, bitfield and encoded metadata)

I guess it is up to the user to ensure this data is saved and restored consistently. I'm not sure whether Buffers should be serialized by node-torrent or by the user. I'm also not sure whether it would be a good idea to persist peer information to speed up torrent restarts.

Upon restoring, invalid pieces are cleared.

I was not able to test this a lot, so this pull request is mainly to get opinions on the implementation for now.
