### PR TITLE
Prevent invalid peer connections

### DIFF
--- a/lib/dht.js
+++ b/lib/dht.js
@@ -1,4 +1,3 @@
-
 var dht = require('dht.js');
 
 var LOGGER = require('log4js').getLogger('dht.js');
@@ -46,6 +45,10 @@ function handleNewPeer(infohash, peer, isAdvertised) {
   LOGGER.debug('Handling peer connection over DHT');
   if (!isAdvertised) {
     LOGGER.debug('Incoming peer connection not advertised, ignoring.');
+    return;
+  }
+  if (peer.port <= 0 || peer.port >= 65536) {
+    LOGGER.debug('Invalid peer socket %s:%s, ignoring.', peer.address, peer.port);
     return;
   }
   if (hashes[infohash]) {


### PR DESCRIPTION
Ignore peer connections with ports outside 1-65535 (which make dht.js throw exceptions)
