### PR TITLE
Prevent torrents from changing client._extensions

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,3 @@
-
 var log4js = require("log4js")
   , net = require("net")
   , dht = require("./dht")
@@ -51,7 +50,7 @@ Client.prototype.addExtension = function(ExtensionClass) {
 };
 
 Client.prototype.addTorrent = function(url) {
-  var torrent = new Torrent(this.id, this.port, this.downloadPath, url, this._extensions);
+  var torrent = new Torrent(this.id, this.port, this.downloadPath, url, this._extensions.slice(0));
   var client = this;
 
   torrent.once(Torrent.INFO_HASH, function(infoHash) {


### PR DESCRIPTION
Without this change, adding several torrents to the same client causes exceptions because torrents change client._extensions (torrent.js:209)
