### PR TITLE
Save ip address from rinfo on successful received messages

### DIFF
--- a/lib/tracker/udp.js
+++ b/lib/tracker/udp.js
@@ -36,6 +36,8 @@ UDP.prototype = {
 
   transactionId: null,
 
+  resolvedIp: null,
+
   handle: function(tracker, data, event, callback) {
 
     this.tracker = tracker;
@@ -45,7 +47,7 @@ UDP.prototype = {
 
     var self = this;
     this.socket = dgram.createSocket('udp4', function(msg, rinfo) {
-      self._handleMessage(msg);
+      self._handleMessage(msg, rinfo);
     }).on('error', function(e) {
       self._complete(null, new Error(e.message));
     });
@@ -113,12 +115,13 @@ UDP.prototype = {
     this.transactionId = id;
   },
 
-  _handleMessage: function(msg) {
+  _handleMessage: function(msg, rinfo) {
     LOGGER.debug('handling message from tracker');
     var action = BufferUtils.readInt(msg);
     var responseTransactionId = BufferUtils.slice(msg, 4, 8);
     console.log(responseTransactionId, this.transactionId);
     if (BufferUtils.equal(responseTransactionId, this.transactionId)) {
+      this.resolvedIp = rinfo.address;
       LOGGER.debug('transactionIds equals, action = ' + action);
       switch (action) {
         case Action.CONNECT:
@@ -147,7 +150,8 @@ UDP.prototype = {
 
   _send: function(packet) {
     var self = this;
-    this.socket.send(packet, 0, packet.length, this.tracker.url.port, this.tracker.url.hostname, function(err) {
+    var host = this.resolvedIp || this.tracker.url.hostname;
+    this.socket.send(packet, 0, packet.length, this.tracker.url.port, host, function(err) {
       LOGGER.debug('packet sent, err = ', err);
       if (err) {
         self._complete(null, err);


### PR DESCRIPTION
This commit saves the resolved IP address of the UDP tracker for further use when it receives a successful message.

This fixes issue #21
