### PR TITLE
Specify encoding when making sha1 of infoHash

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -61,13 +61,13 @@ Metadata.prototype.setMetadata = function(_metadata) {
 
   if (!this.infoHash) {
     this.infoHash = new Buffer(crypto.createHash('sha1')
-      .update(bencode.encode(_metadata))
+      .update(bencode.encode(_metadata), 'ascii')
       .digest(), 'binary');
     LOGGER.debug('Metadata complete.');
     this.emit(Metadata.COMPLETE);
   } else if (this.isComplete()) {
     var infoHash = new Buffer(crypto.createHash('sha1')
-      .update(this._encodedMetadata)
+      .update(this._encodedMetadata, 'ascii')
       .digest(), 'binary');
     if (!BufferUtils.equal(this.infoHash, infoHash)) {
       LOGGER.warn('Metadata is invalid, reseting.');


### PR DESCRIPTION
This is required to calculate the sha1 correctly in node > 5.