### PR TITLE
solving issue #9: Node version 0.10.1 and validating pieces

### DIFF
--- a/lib/piece.js
+++ b/lib/piece.js
@@ -89,7 +89,7 @@ Piece.prototype.isValid = function(cb) {
     if (error) {
       cb(error);
     } else {
-      var dataHash = crypto.createHash('sha1').update(data).digest();
+      var dataHash = crypto.createHash('sha1').update(data).digest('binary');
       cb(self.hash === dataHash);
     }
   });


### PR DESCRIPTION
I realized that the downloaded attribute from torrent.state wasn't being updated on the latest versions of node. And the reason is that the comparison between hashes wasn't being between variables of the same type. On newest versions of Node, the digest method requires an encoding in order to return a string value. If nothing is passed, this method returns a Buffer and the pieces comparison is never valid. In older versions like 0.8 and 0.9, if nothing is passed to this method, it returns a string with 'binary' encoding by default.

Just adding the encoding 'binary' to digest method solves the issue.