### PR TITLE
fixed error with log4js LOGGER, which crashes app with TypeError

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -21,9 +21,7 @@ var Client = function(options) {
 
   options = options || {};
 
-  var logger = log4js.getLogger();
-  logger.level = 'warn';
-  logger.debug("Some debug messages");
+  log4js.getLogger().level = 'warn'
 
   var id = options.id || '-NT0010-';
   if (id instanceof Buffer) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,7 +21,9 @@ var Client = function(options) {
 
   options = options || {};
 
-  log4js.setGlobalLogLevel(log4js.levels[options.logLevel || 'WARN']);
+  var logger = log4js.getLogger();
+  logger.level = 'warn';
+  logger.debug("Some debug messages");
 
   var id = options.id || '-NT0010-';
   if (id instanceof Buffer) {


### PR DESCRIPTION
Apps, using node-torrent from npm crash with "TypeError: log4js.setGlobalLogLevel is not a function". That modification fixes that issue with no additional changes.