### PR TITLE
Updated Buffer constructor usage

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -111,7 +111,7 @@ function listen(server, portRange) {
 
 function padId(id) {
   
-  var newId = new Buffer(20);
+  var newId = new Buffer.alloc(20);
   newId.write(id, 0, 'ascii');
   
   var start = id.length;

--- a/lib/message.js
+++ b/lib/message.js
@@ -13,7 +13,7 @@ Message.prototype.writeTo = function(stream) {
     var length = 1 + (this.payload ? this.payload.length : 0);
     stream.write(BufferUtils.fromInt(length));
     
-    var code = new Buffer(1);
+    var code = new Buffer.alloc(1);
     code[0] = this.code;
     stream.write(code);
     

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -33,7 +33,7 @@ Metadata.prototype.setLength = function(length) {
   this._length = length;
   if (!this._encodedMetadata || this._encodedMetadata.length !== length) {
     this.bitfield = new BitField(Math.ceil(length / Metadata.BLOCK_SIZE));
-    this._encodedMetadata = new Buffer(length);
+    this._encodedMetadata = new Buffer.alloc(length);
   }
 };
 
@@ -52,7 +52,7 @@ Metadata.prototype.setMetadata = function(_metadata) {
     LOGGER.debug(this._encodedMetadata.length);
     LOGGER.debug(_metadata.pieces.length);
     LOGGER.debug(typeof(_metadata.pieces));
-    this._encodedMetadata = new Buffer(bencode.encode(_metadata));
+    this._encodedMetadata = new Buffer.alloc(Buffer.byteLength(bencode.encode(_metadata)), bencode.encode(_metadata));
     LOGGER.debug(this._encodedMetadata.length);
     
     this.setLength(this._encodedMetadata.length);
@@ -60,15 +60,17 @@ Metadata.prototype.setMetadata = function(_metadata) {
   }
 
   if (!this.infoHash) {
-    this.infoHash = new Buffer(crypto.createHash('sha1')
+    var digest = crypto.createHash('sha1')
       .update(bencode.encode(_metadata), 'ascii')
-      .digest(), 'binary');
+      .digest();
+    this.infoHash = new Buffer.alloc(Buffer.byteLength(digest), digest, 'binary');
     LOGGER.debug('Metadata complete.');
     this.emit(Metadata.COMPLETE);
   } else if (this.isComplete()) {
-    var infoHash = new Buffer(crypto.createHash('sha1')
-      .update(this._encodedMetadata, 'ascii')
-      .digest(), 'binary');
+    var digest = crypto.createHash('sha1')
+      .update(bencode.encode(_metadata), 'ascii')
+      .digest();
+    var infoHash = new Buffer.alloc(Buffer.byteLength(digest), digest, 'binary');
     if (!BufferUtils.equal(this.infoHash, infoHash)) {
       LOGGER.warn('Metadata is invalid, reseting.');
       this.bitfield.unsetAll();

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -10,7 +10,9 @@ var EventEmitter = require('events').EventEmitter;
 var Message = require('./message');
 var Piece = require('./piece');
 
-var BITTORRENT_HEADER = new Buffer("\x13BitTorrent protocol\x00\x00\x00\x00\x00\x10\x00\x00", "binary");
+var protocolHeaderStr = "\x13BitTorrent protocol\x00\x00\x00\x00\x00\x10\x00\x00";
+
+var BITTORRENT_HEADER = new Buffer.alloc( Buffer.byteLength(protocolHeaderStr), protocolHeaderStr, "binary");
 var KEEPALIVE_PERIOD = 120000;
 var MAX_REQUESTS = 10;
 
@@ -20,7 +22,7 @@ var Peer = function(/* stream */ /* or */ /* peer_id, address, port, torrent */)
   EventEmitter.call(this);
 
   this.choked = true;
-  this.data = new Buffer(0);
+  this.data = new Buffer.alloc(0);
   this.drained = true;
   this.initialised = false;
   this.interested = false;
@@ -147,7 +149,7 @@ Peer.prototype.requestPiece = function(piece) {
     var nextChunk;
     while (self.numRequests < MAX_REQUESTS && (nextChunk = piece.nextChunk())) {
       self.requests[piece.index][nextChunk.begin] = new Date();
-      var msgBuffer = new Buffer(12);
+      var msgBuffer = new Buffer.alloc(12);
       msgBuffer.writeInt32BE(piece.index, 0, true);
       msgBuffer.writeInt32BE(nextChunk.begin, 4, true);
       msgBuffer.writeInt32BE(nextChunk.length, 8, true);
@@ -184,12 +186,12 @@ Peer.prototype.sendExtendedMessage = function(type, data) {
 
   if (code !== undefined) {
     
-    var codeAsBuffer = new Buffer(1);
+    var codeAsBuffer = new Buffer.alloc(1);
     codeAsBuffer[0] = code;
 
     LOGGER.debug('Peer [%s] extended request code = %j', this.getIdentifier(), codeAsBuffer[0]);
 
-    var payload = new Buffer(bencode.encode(data));
+    var payload = new Buffer.alloc(Buffer.byteLength(bencode.encode(data)), bencode.encode(data));
 
     var message = new Message(Message.EXTENDED, BufferUtils.concat(codeAsBuffer, payload));
 
@@ -373,7 +375,7 @@ function sendData(self) {
         }
         else {
           if (data) {
-            var msgBuffer = new Buffer(8+data.length);
+            var msgBuffer = new Buffer.alloc(8+data.length);
             msgBuffer.writeInt32BE(index, 0, true);
             msgBuffer.writeInt32BE(begin, 4, true);
             data.copy(msgBuffer, 8);

--- a/lib/piece.js
+++ b/lib/piece.js
@@ -53,7 +53,7 @@ Piece.prototype.cancelRequest = function(begin) {
 };
 
 Piece.prototype.getData = function(begin, length, cb) {
-  var data = new Buffer(length)
+  var data = new Buffer.alloc(length)
     , dataOffset = 0
     , files = this.files.slice(0)
     , self = this

--- a/lib/torrentdata/magnet.js
+++ b/lib/torrentdata/magnet.js
@@ -34,9 +34,9 @@ var MagnetMetadata = {
 		} else {
 			var infoHash;
 			if (hash.length === 40) {
-				infoHash = new Buffer(hash, 'hex');
+				infoHash = new Buffer.alloc(40, hash, 'hex');
 			} else {
-				infoHash = new Buffer(base32.decode(hash), 'binary');
+				infoHash = new Buffer.alloc(Buffer.byteLength(base32.decode(hash)), base32.decode(hash), 'binary');
 			}
 
 			if (parsedUrl.query.tr) {

--- a/lib/tracker/http.js
+++ b/lib/tracker/http.js
@@ -61,7 +61,7 @@ HTTP.prototype = {
         length += chunk.length;
       });
       res.on('end', function() {
-        var body = new Buffer(length);
+        var body = new Buffer.alloc(length);
         var pos = 0;
         for (var i = 0; i < buffers.length; i++) {
           body.write(buffers[i].toString('binary'), pos, 'binary');
@@ -95,7 +95,7 @@ HTTP.prototype = {
 
       if (response.peers) {
 				if (typeof(response.peers) === 'string') {
-					var peers = new Buffer(response.peers, 'binary');
+					var peers = new Buffer.alloc(Buffer.byteLength(response.peers), response.peers , 'binary');
 					for (var i = 0; i < peers.length; i += 6) {
 						var ip = peers[i] + '.' + peers[i + 1] + '.' + peers[i + 2] + '.' + peers[i + 3];
 						var port = peers[i + 4] << 8 | peers[i + 5];

--- a/lib/tracker/udp.js
+++ b/lib/tracker/udp.js
@@ -107,7 +107,7 @@ UDP.prototype = {
 
   _generateTransactionId: function() {
     LOGGER.debug('generating transaction id');
-    var id = new Buffer(4);
+    var id = new Buffer.alloc(4);
     id[0] = Math.random() * 255;
     id[1] = Math.random() * 255;
     id[2] = Math.random() * 255;

--- a/lib/util/bitfield.js
+++ b/lib/util/bitfield.js
@@ -106,7 +106,7 @@ BitField.prototype.unsetAll = function() {
 
 function toBuffer(array) {
 
-  var buffer = new Buffer(Math.ceil(array.length / 8));
+  var buffer = new Buffer.alloc(Math.ceil(array.length / 8));
   
   for (var i = 0; i < buffer.length; i++) {
     buffer[i] = 0;

--- a/lib/util/bufferutils.js
+++ b/lib/util/bufferutils.js
@@ -4,7 +4,7 @@ function concat() {
   for (var i = 0; i < arguments.length; i++) {
     length += arguments[i].length;
   }
-  var nb = new Buffer(length);
+  var nb = new Buffer.alloc(length);
   var pos = 0;
   for (var i = 0; i < arguments.length; i++) {
     var b = arguments[i];
@@ -27,7 +27,7 @@ function equal(b1, b2) {
 }
 
 function fromInt(int) {
-  var b = new Buffer(4);
+  var b = new Buffer.alloc(4);
   b[0] = int >> 24 & 0xff;
   b[1] = int >> 16 & 0xff;
   b[2] = int >> 8 & 0xff;
@@ -44,7 +44,7 @@ function readInt(buffer, offset) {
 }
 
 function fromInt16(int) {
-  var b = new Buffer(2);
+  var b = new Buffer.alloc(2);
   b[2] = int >> 8 & 0xff;
   b[3] = int & 0xff;
   return b;
@@ -60,7 +60,7 @@ function slice(buffer, start, end) {
   if (start < 0) start = 0;
   if (!end || end > buffer.length) end = buffer.length;
   
-  var b = new Buffer(end - start);
+  var b = new Buffer.alloc(end - start);
   buffer.copy(b, 0, start, end);
   return b;
 }


### PR DESCRIPTION
This PR updated Buffer() usage to get rid of a deprecation warning message.
Changed all Buffer construction to Buffer.alloc() .